### PR TITLE
Add region capability on Copy and Move methods

### DIFF
--- a/connectors/s3-connector/src/main/scala/zio/connect/s3/TestS3Connector.scala
+++ b/connectors/s3-connector/src/main/scala/zio/connect/s3/TestS3Connector.scala
@@ -8,49 +8,46 @@ import zio.stream.{ZSink, ZStream}
 import zio.{Chunk, Trace, ZIO, ZLayer}
 
 private[s3] final case class TestS3Connector(s3: TestS3) extends S3Connector {
-  override def copyObject(implicit
+  override def copyObject(region: => Region)(implicit
     trace: Trace
   ): ZSink[Any, S3Connector.S3Exception, S3Connector.CopyObject, S3Connector.CopyObject, Unit] =
-    ZSink.foreach(copyObject => s3.copyObject(copyObject))
+    ZSink.foreach(copyObject => s3.copyObject(copyObject, region, region))
 
-  override def createBucket(implicit trace: Trace): ZSink[Any, S3Connector.S3Exception, BucketName, BucketName, Unit] =
-    ZSink.foreach(name => s3.createBucket(name))
+  override def createBucket(region: => Region)(implicit
+    trace: Trace
+  ): ZSink[Any, S3Connector.S3Exception, BucketName, BucketName, Unit] =
+    ZSink.foreach(name => s3.createBucket(name, region))
 
-  override def deleteEmptyBucket(implicit
+  override def deleteEmptyBucket(region: => Region)(implicit
     trace: Trace
   ): ZSink[Any, S3Connector.S3Exception, BucketName, BucketName, Unit] =
     ZSink.foreach(bucket => s3.deleteEmptyBucket(bucket))
 
-  override def deleteObjects(bucketName: => BucketName)(implicit
+  override def deleteObjects(bucketName: => BucketName, region: => Region)(implicit
     trace: Trace
   ): ZSink[Any, S3Connector.S3Exception, ObjectKey, ObjectKey, Unit] =
     ZSink.foreach(key => s3.deleteObject(bucketName, key))
 
-  override def getObject(bucketName: => BucketName, key: => ObjectKey)(implicit
+  override def getObject(bucketName: => BucketName, key: => ObjectKey, region: => Region)(implicit
     trace: Trace
   ): ZStream[Any, S3Connector.S3Exception, Byte] =
-    s3.getObject(bucketName, key)
+    s3.getObject(bucketName, key, region)
 
-  override def listBuckets(implicit trace: Trace): ZStream[Any, S3Exception, BucketName] =
+  override def listBuckets(region: => Region)(implicit trace: Trace): ZStream[Any, S3Exception, BucketName] =
     ZStream.fromIterableZIO(s3.listBuckets)
 
-  override def listObjects(bucketName: => BucketName)(implicit
+  override def listObjects(bucketName: => BucketName, region: => Region)(implicit
     trace: Trace
   ): ZStream[Any, S3Connector.S3Exception, ObjectKey] =
     ZStream.fromIterableZIO(s3.listObjects(bucketName))
 
-  override def moveObject(implicit
-    trace: Trace
-  ): ZSink[Any, S3Connector.S3Exception, S3Connector.MoveObject, S3Connector.MoveObject, Unit] =
-    ZSink.foreach(moveObject => s3.moveObject(moveObject))
-
-  override def putObject(bucketName: => BucketName, key: => ObjectKey)(implicit
+  override def putObject(bucketName: => BucketName, key: => ObjectKey, region: => Region)(implicit
     trace: Trace
   ): ZSink[Any, S3Connector.S3Exception, Byte, Nothing, Unit] =
     ZSink.unwrap(for {
       ref <- TRef.makeCommit(false)
       r = ZSink.foreachChunk[Any, S3Connector.S3Exception, Byte] { bytes =>
-            s3.putObject(bucketName, key, bytes, ref)
+            s3.putObject(bucketName, key, bytes, ref, region)
           }
     } yield r)
 }
@@ -60,7 +57,7 @@ object TestS3Connector {
   val layer: ZLayer[Any, Nothing, TestS3Connector] =
     ZLayer.fromZIO(STM.atomically {
       for {
-        a <- TRef.make(Map.empty[BucketName, S3Bucket])
+        a <- TRef.make(Map.empty[(BucketName, Region), S3Bucket])
       } yield TestS3Connector(TestS3(a))
     })
 
@@ -72,49 +69,48 @@ object TestS3Connector {
     final case class S3Obj(key: ObjectKey, content: Chunk[Byte]) extends S3Node
   }
 
-  private[s3] final case class TestS3(repo: TRef[Map[BucketName, S3Bucket]]) {
-
+  private[s3] final case class TestS3(repo: TRef[Map[(BucketName, Region), S3Bucket]]) {
     private def bucketDoesntExistException(name: BucketName): S3Exception =
       S3Exception(new RuntimeException(s"Bucket $name doesn't exist"))
 
-    def copyObject(m: CopyObject): ZIO[Any, S3Exception, Unit] =
+    def copyObject(m: CopyObject, sourceRegion: => Region, destinationRegion: => Region): ZIO[Any, S3Exception, Unit] =
       ZSTM.atomically(for {
         map <- repo.get
         sourceBucket <-
           ZSTM
-            .fromOption(map.get(m.sourceBucketName))
+            .fromOption(map.get((m.sourceBucketName, sourceRegion)))
             .mapError(_ => bucketDoesntExistException(m.sourceBucketName))
         destinationBucket <-
           ZSTM
-            .fromOption(map.get(m.targetBucketName))
+            .fromOption(map.get((m.targetBucketName, destinationRegion)))
             .mapError(_ => bucketDoesntExistException(m.targetBucketName))
         sourceObject <-
           ZSTM.fromOption(sourceBucket.objects.get(m.objectKey)).mapError(_ => objectDoesntExistException(m.objectKey))
         _ <- repo.update(mp =>
                mp.updated(
-                 destinationBucket.name,
+                 (destinationBucket.name, destinationRegion),
                  S3Bucket(destinationBucket.name, destinationBucket.objects.updated(m.objectKey, sourceObject))
                )
              )
       } yield ())
 
-    def createBucket(name: BucketName): ZIO[Any, S3Exception, Unit] =
+    def createBucket(name: BucketName, region: => Region): ZIO[Any, S3Exception, Unit] =
       ZSTM.atomically(
         for {
-          bucket <- repo.get.map(_.get(name))
+          bucket <- repo.get.map(_.get((name, region)))
           _ <- if (bucket.isDefined) ZSTM.succeed(())
-               else repo.getAndUpdate(m => m.updated(name, S3Bucket(name, Map.empty)))
+               else repo.getAndUpdate(m => m.updated((name, region), S3Bucket(name, Map.empty)))
         } yield ()
       )
 
     def deleteEmptyBucket(bucket: BucketName): ZIO[Any, S3Exception, Unit] =
       ZSTM.atomically(
         for {
-          bucketOp <- repo.get.map(_.get(bucket))
+          bucketOp <- repo.get.map(_.get((bucket, usEast1Region)))
           _ <-
             bucketOp match {
               case Some(b) =>
-                if (b.objects.isEmpty) repo.getAndUpdate(m => m - bucket)
+                if (b.objects.isEmpty) repo.getAndUpdate(m => m - ((bucket, usEast1Region)))
                 else ZSTM.fail(S3Exception(new RuntimeException("Bucket not empty")))
               case None =>
                 ZSTM.fail(S3Exception(new RuntimeException("Bucket does not exist")))
@@ -128,26 +124,27 @@ object TestS3Connector {
           map <- repo.get
           bucket <-
             ZSTM
-              .fromOption(map.get(bucket))
+              .fromOption(map.get((bucket, usEast1Region)))
               .mapError(_ => bucketDoesntExistException(bucket))
-          _ <- repo.set(map.updated(bucket.name, S3Bucket(bucket.name, bucket.objects - key)))
+          _ <- repo.set(map.updated((bucket.name, usEast1Region), S3Bucket(bucket.name, bucket.objects - key)))
         } yield ()
       )
 
-    def getObject(bucketName: BucketName, key: ObjectKey): ZStream[Any, S3Exception, Byte] =
+    def getObject(bucketName: BucketName, key: ObjectKey, region: => Region): ZStream[Any, S3Exception, Byte] =
       ZStream.unwrap(
         ZSTM.atomically(
           for {
-            map    <- repo.get
-            bucket <- ZSTM.fromOption(map.get(bucketName)).orElseFail(bucketDoesntExistException(bucketName))
-            obj    <- ZSTM.fromOption(bucket.objects.get(key)).orElseFail(objectDoesntExistException(key))
+            map <- repo.get
+            bucket <-
+              ZSTM.fromOption(map.get((bucketName, region))).orElseFail(bucketDoesntExistException(bucketName))
+            obj <- ZSTM.fromOption(bucket.objects.get(key)).orElseFail(objectDoesntExistException(key))
           } yield ZStream.fromChunk(obj.content)
         )
       )
 
     def listBuckets: ZIO[Any, S3Exception, Chunk[BucketName]] =
       ZSTM.atomically(
-        repo.get.map(_.keys).map(Chunk.fromIterable)
+        repo.get.map(_.keys).map(k => Chunk.fromIterable(k.map(_._1)))
       )
 
     def listObjects(bucketName: BucketName): ZIO[Any, S3Exception, Chunk[ObjectKey]] =
@@ -155,32 +152,35 @@ object TestS3Connector {
         for {
           map <- repo.get
           bucket <- ZSTM
-                      .fromOption(map.get(bucketName))
+                      .fromOption(map.get((bucketName, usEast1Region)))
                       .mapError { _ =>
                         S3Exception(new RuntimeException("No such bucket!"))
                       }
         } yield Chunk.fromIterable(bucket.objects.keys)
       )
 
-    def moveObject(m: MoveObject): ZIO[Any, S3Exception, Unit] =
+    def moveObject(m: MoveObject, sourceRegion: => Region, destinationRegion: => Region): ZIO[Any, S3Exception, Unit] =
       ZSTM.atomically(for {
         map <- repo.get
         sourceBucket <-
           ZSTM
-            .fromOption(map.get(m.bucketName))
+            .fromOption(map.get((m.bucketName, sourceRegion)))
             .mapError(_ => bucketDoesntExistException(m.bucketName))
         destinationBucket <-
           ZSTM
-            .fromOption(map.get(m.targetBucketName))
+            .fromOption(map.get((m.targetBucketName, destinationRegion)))
             .mapError(_ => bucketDoesntExistException(m.targetBucketName))
         sourceObject <-
           ZSTM.fromOption(sourceBucket.objects.get(m.objectKey)).mapError(_ => objectDoesntExistException(m.objectKey))
         _ <- repo.update { mp =>
                val m1 = mp.updated(
-                 destinationBucket.name,
+                 (destinationBucket.name, destinationRegion),
                  S3Bucket(destinationBucket.name, destinationBucket.objects.updated(m.targetObjectKey, sourceObject))
                )
-               m1.updated(sourceBucket.name, S3Bucket(sourceBucket.name, sourceBucket.objects - m.objectKey))
+               m1.updated(
+                 (sourceBucket.name, sourceRegion),
+                 S3Bucket(sourceBucket.name, sourceBucket.objects - m.objectKey)
+               )
              }
       } yield ())
 
@@ -191,19 +191,20 @@ object TestS3Connector {
       bucketName: BucketName,
       key: ObjectKey,
       bytes: Chunk[Byte],
-      append: TRef[Boolean]
+      append: TRef[Boolean],
+      region: => Region
     ): ZIO[Any, S3Connector.S3Exception, Unit] =
       ZSTM.atomically(
         for {
           map       <- repo.get
           appending <- append.get
           bucket <- ZSTM
-                      .fromOption(map.get(bucketName))
+                      .fromOption(map.get((bucketName, region)))
                       .mapError(_ => bucketDoesntExistException(bucketName))
           updatedMap =
             if (appending)
               map.updated(
-                bucketName,
+                (bucketName, region),
                 S3Bucket(
                   bucketName,
                   bucket.objects.updated(
@@ -212,7 +213,11 @@ object TestS3Connector {
                   )
                 )
               )
-            else map.updated(bucketName, S3Bucket(bucketName, bucket.objects.updated(key, S3Obj(key, bytes))))
+            else
+              map.updated(
+                (bucketName, region),
+                S3Bucket(bucketName, bucket.objects.updated(key, S3Obj(key, bytes)))
+              )
           _ <- repo.set(updatedMap)
           _ <- append.set(true)
         } yield ()

--- a/connectors/s3-connector/src/main/scala/zio/connect/s3/package.scala
+++ b/connectors/s3-connector/src/main/scala/zio/connect/s3/package.scala
@@ -1,56 +1,80 @@
 package zio.connect
 
 import zio.aws.s3.S3
-import zio.connect.s3.S3Connector.{BucketName, CopyObject, ObjectKey, S3Exception}
+import zio.connect.s3.S3Connector.{BucketName, CopyObject, ObjectKey, Region, S3Exception}
 import zio.stream.{ZSink, ZStream}
 import zio.{Trace, ZLayer}
 
 package object s3 {
+  val usEast1Region = "us-east-1"
+  val usWest2Region = "us-west-2"
 
-  def copyObject(implicit trace: Trace): ZSink[S3Connector, S3Exception, CopyObject, CopyObject, Unit] =
-    ZSink.serviceWithSink(_.copyObject)
+  def copyObject(region: => Region = usEast1Region)(implicit
+    trace: Trace
+  ): ZSink[S3Connector, S3Exception, CopyObject, CopyObject, Unit] =
+    ZSink.serviceWithSink(_.copyObject(region))
 
-  def createBucket(implicit trace: Trace): ZSink[S3Connector, S3Exception, BucketName, BucketName, Unit] =
-    ZSink.serviceWithSink(_.createBucket)
+  def copyObject(sourceRegion: => Region, destinationRegion: => Region)(implicit
+    trace: Trace
+  ): ZSink[S3Connector, S3Exception, CopyObject, CopyObject, Unit] =
+    ZSink.serviceWithSink(_.copyObject(sourceRegion, destinationRegion))
 
-  def deleteEmptyBucket(implicit trace: Trace): ZSink[S3Connector, S3Exception, BucketName, BucketName, Unit] =
-    ZSink.serviceWithSink(_.deleteEmptyBucket)
+  def createBucket(region: => Region = usEast1Region)(implicit
+    trace: Trace
+  ): ZSink[S3Connector, S3Exception, BucketName, BucketName, Unit] =
+    ZSink.serviceWithSink(_.createBucket(region))
 
-  def deleteObjects(bucketName: BucketName)(implicit
+  def deleteEmptyBucket(region: => Region = usEast1Region)(implicit
+    trace: Trace
+  ): ZSink[S3Connector, S3Exception, BucketName, BucketName, Unit] =
+    ZSink.serviceWithSink(_.deleteEmptyBucket(region))
+
+  def deleteObjects(bucketName: BucketName, region: => Region)(implicit
     trace: Trace
   ): ZSink[S3Connector, S3Exception, ObjectKey, ObjectKey, Unit] =
-    ZSink.serviceWithSink(_.deleteObjects(bucketName))
+    ZSink.serviceWithSink(_.deleteObjects(bucketName, region))
 
-  def existsBucket(implicit trace: Trace): ZSink[S3Connector, S3Exception, BucketName, BucketName, Boolean] =
-    ZSink.serviceWithSink(_.existsBucket)
+  def existsBucket(region: => Region = usEast1Region)(implicit
+    trace: Trace
+  ): ZSink[S3Connector, S3Exception, BucketName, BucketName, Boolean] =
+    ZSink.serviceWithSink(_.existsBucket(region))
 
-  def existsObject(bucketName: => BucketName)(implicit
+  def existsObject(bucketName: => BucketName, region: => Region)(implicit
     trace: Trace
   ): ZSink[S3Connector, S3Exception, ObjectKey, ObjectKey, Boolean] =
-    ZSink.serviceWithSink(_.existsObject(bucketName))
+    ZSink.serviceWithSink(_.existsObject(bucketName, region))
 
-  def getObject(bucketName: => BucketName, key: ObjectKey)(implicit
+  def getObject(bucketName: => BucketName, key: ObjectKey, region: => Region)(implicit
     trace: Trace
   ): ZStream[S3Connector, S3Exception, Byte] =
-    ZStream.serviceWithStream(_.getObject(bucketName, key))
+    ZStream.serviceWithStream(_.getObject(bucketName, key, region))
 
-  def listBuckets(implicit trace: Trace): ZStream[S3Connector, S3Exception, BucketName] =
-    ZStream.serviceWithStream(_.listBuckets)
+  def listBuckets(region: => Region = usEast1Region)(implicit
+    trace: Trace
+  ): ZStream[S3Connector, S3Exception, BucketName] =
+    ZStream.serviceWithStream(_.listBuckets(region))
 
-  def listObjects(bucketName: => BucketName)(implicit trace: Trace): ZStream[S3Connector, S3Exception, ObjectKey] =
-    ZStream.serviceWithStream(_.listObjects(bucketName))
+  def listObjects(bucketName: => BucketName, region: => Region)(implicit
+    trace: Trace
+  ): ZStream[S3Connector, S3Exception, ObjectKey] =
+    ZStream.serviceWithStream(_.listObjects(bucketName, region))
 
-  def moveObject(implicit
+  def moveObject(region: => Region = usEast1Region)(implicit
     trace: Trace
   ): ZSink[S3Connector, S3Exception, S3Connector.MoveObject, S3Connector.MoveObject, Unit] =
-    ZSink.serviceWithSink(_.moveObject)
+    ZSink.serviceWithSink(_.moveObject(region))
 
-  val s3ConnectorLiveLayer: ZLayer[S3, Nothing, LiveS3Connector]  = LiveS3Connector.layer
-  val s3ConnectorTestLayer: ZLayer[Any, Nothing, TestS3Connector] = TestS3Connector.layer
+  def moveObject(sourceRegion: => Region, destinationRegion: => Region)(implicit
+    trace: Trace
+  ): ZSink[S3Connector, S3Exception, S3Connector.MoveObject, S3Connector.MoveObject, Unit] =
+    ZSink.serviceWithSink(_.moveObject(sourceRegion, destinationRegion))
 
-  def putObject(bucketName: => BucketName, key: ObjectKey)(implicit
+  val s3ConnectorLiveLayer: ZLayer[Map[Region, S3], Nothing, LiveS3Connector] = LiveS3Connector.layer
+  val s3ConnectorTestLayer: ZLayer[Any, Nothing, TestS3Connector]             = TestS3Connector.layer
+
+  def putObject(bucketName: => BucketName, key: ObjectKey, region: => Region = usEast1Region)(implicit
     trace: Trace
   ): ZSink[S3Connector, S3Exception, Byte, Nothing, Unit] =
-    ZSink.serviceWithSink(_.putObject(bucketName, key))
+    ZSink.serviceWithSink(_.putObject(bucketName, key, region))
 
 }

--- a/connectors/s3-connector/src/test/scala/zio/connect/s3/LiveS3ConnectorSpec.scala
+++ b/connectors/s3-connector/src/test/scala/zio/connect/s3/LiveS3ConnectorSpec.scala
@@ -3,11 +3,12 @@ import org.testcontainers.containers.localstack.LocalStackContainer
 import org.testcontainers.containers.localstack.LocalStackContainer.Service
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
-import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.{Region => AWSRegion}
 import zio.aws.core.config.AwsConfig
 import zio.aws.core.httpclient.HttpClient
 import zio.aws.netty.NettyHttpClient
 import zio.aws.s3.S3
+import zio.connect.s3.S3Connector.Region
 import zio.{Scope, ZIO, ZLayer}
 
 object LiveS3ConnectorSpec extends S3ConnectorSpec {
@@ -34,20 +35,35 @@ object LiveS3ConnectorSpec extends S3ConnectorSpec {
       })(ls => ZIO.attempt(ls.stop()).orDie)
     )
 
-  lazy val s3: ZLayer[AwsConfig with LocalStackContainer, Throwable, S3] =
+  lazy val s3 = {
+    val res = for {
+      localstack <- ZIO.service[LocalStackContainer]
+      s3USWest2 <- ZIO
+                     .service[S3]
+                     .provideSome[AwsConfig](
+                       S3.customized(
+                         _.credentialsProvider(
+                           StaticCredentialsProvider
+                             .create(AwsBasicCredentials.create(localstack.getAccessKey, localstack.getSecretKey))
+                         ).region(AWSRegion.US_WEST_2)
+                           .endpointOverride(localstack.getEndpointOverride(Service.S3))
+                       )
+                     )
+      s3USEast1 <- ZIO
+                     .service[S3]
+                     .provideSome[AwsConfig](
+                       S3.customized(
+                         _.credentialsProvider(
+                           StaticCredentialsProvider
+                             .create(AwsBasicCredentials.create(localstack.getAccessKey, localstack.getSecretKey))
+                         ).region(AWSRegion.of(localstack.getRegion))
+                           .endpointOverride(localstack.getEndpointOverride(Service.S3))
+                       )
+                     )
+
+    } yield Map(Region("us-east-1") -> s3USEast1, Region("us-west-2") -> s3USWest2)
     ZLayer
-      .fromZIO(for {
-        localstack <- ZIO.service[LocalStackContainer]
-        s <- ZIO.succeed(
-               S3.customized(
-                 _.credentialsProvider(
-                   StaticCredentialsProvider
-                     .create(AwsBasicCredentials.create(localstack.getAccessKey, localstack.getSecretKey))
-                 ).region(Region.of(localstack.getRegion))
-                   .endpointOverride(localstack.getEndpointOverride(Service.S3))
-               )
-             )
-      } yield s)
-      .flatMap(_.get)
+      .fromZIO(res)
+  }
 
 }

--- a/connectors/s3-connector/src/test/scala/zio/connect/s3/S3ConnectorSpec.scala
+++ b/connectors/s3-connector/src/test/scala/zio/connect/s3/S3ConnectorSpec.scala
@@ -20,13 +20,13 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
         val bucket2 = BucketName(UUID.randomUUID().toString)
         val key     = ObjectKey(UUID.randomUUID().toString)
         for {
-          _             <- ZStream(bucket1, bucket2) >>> createBucket
+          _             <- ZStream(bucket1, bucket2) >>> createBucket()
           content1      <- Random.nextBytes(5)
           content2      <- Random.nextBytes(5)
           _             <- ZStream.fromChunk(content1) >>> putObject(bucket1, key)
           _             <- ZStream.fromChunk(content2) >>> putObject(bucket2, key)
-          _             <- ZStream(S3Connector.CopyObject(bucket1, key, bucket2)) >>> copyObject
-          copiedContent <- getObject(bucket2, key).runCollect
+          _             <- ZStream(S3Connector.CopyObject(bucket1, key, bucket2)) >>> copyObject()
+          copiedContent <- getObject(bucket2, key, usEast1Region).runCollect
         } yield assertTrue(copiedContent == content1)
       },
       test("succeeds") {
@@ -35,16 +35,16 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
         val object2 = ObjectKey(UUID.randomUUID().toString)
         val bucket2 = BucketName(UUID.randomUUID().toString)
         for {
-          _              <- ZStream(bucket1, bucket2) >>> createBucket
+          _              <- ZStream(bucket1, bucket2) >>> createBucket()
           o1Content      <- Random.nextBytes(5)
           o2Content      <- Random.nextBytes(5)
           _              <- ZStream.fromChunk(o1Content) >>> putObject(bucket1, object1)
           _              <- ZStream.fromChunk(o2Content) >>> putObject(bucket1, object2)
-          initialFiles   <- listObjects(bucket1).runCollect
-          _              <- ZStream(CopyObject(bucket1, object1, bucket2), CopyObject(bucket1, object2, bucket2)) >>> copyObject
-          copiedFiles    <- listObjects(bucket2).runCollect
-          copiedContent1 <- getObject(bucket2, object1).runCollect
-          copiedContent2 <- getObject(bucket2, object2).runCollect
+          initialFiles   <- listObjects(bucket1, usEast1Region).runCollect
+          _              <- ZStream(CopyObject(bucket1, object1, bucket2), CopyObject(bucket1, object2, bucket2)) >>> copyObject()
+          copiedFiles    <- listObjects(bucket2, usEast1Region).runCollect
+          copiedContent1 <- getObject(bucket2, object1, usEast1Region).runCollect
+          copiedContent2 <- getObject(bucket2, object2, usEast1Region).runCollect
 
           filesWereCopied =
             Chunk(object1, object2).sortBy(_.toString) == initialFiles.sortBy(_.toString) &&
@@ -52,6 +52,21 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
           o1CopyMatchesOriginal = o1Content == copiedContent1
           o2CopyMatchesOriginal = o2Content == copiedContent2
         } yield assertTrue(filesWereCopied) && assertTrue(o1CopyMatchesOriginal) && assertTrue(o2CopyMatchesOriginal)
+      },
+      test("replaces preexisting object cross region") {
+        val bucket1 = BucketName(UUID.randomUUID().toString)
+        val bucket2 = BucketName(UUID.randomUUID().toString)
+        val key     = ObjectKey(UUID.randomUUID().toString)
+        for {
+          _             <- ZStream(bucket1) >>> createBucket()
+          _             <- ZStream(bucket2) >>> createBucket(usWest2Region)
+          content1      <- Random.nextBytes(5)
+          content2      <- Random.nextBytes(5)
+          _             <- ZStream.fromChunk(content1) >>> putObject(bucket1, key)
+          _             <- ZStream.fromChunk(content2) >>> putObject(bucket2, key, usWest2Region)
+          _             <- ZStream(S3Connector.CopyObject(bucket1, key, bucket2)) >>> copyObject(usEast1Region, usWest2Region)
+          copiedContent <- getObject(bucket2, key, usWest2Region).runCollect
+        } yield assertTrue(copiedContent == content1)
       }
     )
 
@@ -60,21 +75,21 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
       test("changes nothing if bucket already exists") {
         val bucketName = BucketName(UUID.randomUUID().toString)
         for {
-          _             <- ZStream(bucketName) >>> createBucket
+          _             <- ZStream(bucketName) >>> createBucket()
           content       <- Random.nextBytes(5)
           _             <- ZStream.fromChunk(content) >>> putObject(bucketName, ObjectKey(UUID.randomUUID().toString))
-          objectsBefore <- listObjects(bucketName).runCollect
-          _             <- ZStream(bucketName) >>> createBucket
-          objectsAfter  <- listObjects(bucketName).runCollect
+          objectsBefore <- listObjects(bucketName, usEast1Region).runCollect
+          _             <- ZStream(bucketName) >>> createBucket()
+          objectsAfter  <- listObjects(bucketName, usEast1Region).runCollect
         } yield assertTrue(objectsBefore == objectsAfter)
       },
       test("succeeds") {
         val bucketName = BucketName(UUID.randomUUID().toString)
         for {
-          _          <- ZStream.succeed(bucketName) >>> createBucket
-          wasCreated <- ZStream(bucketName) >>> existsBucket
-          _          <- ZStream.succeed(bucketName) >>> deleteEmptyBucket
-          wasDeleted <- (ZStream(bucketName) >>> existsBucket).map(!_)
+          _          <- ZStream.succeed(bucketName) >>> createBucket()
+          wasCreated <- ZStream(bucketName) >>> existsBucket()
+          _          <- ZStream.succeed(bucketName) >>> deleteEmptyBucket()
+          wasDeleted <- (ZStream(bucketName) >>> existsBucket()).map(!_)
         } yield assertTrue(wasCreated) && assertTrue(wasDeleted)
       }
     )
@@ -84,20 +99,21 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
       test("fails if bucket is not empty") {
         val bucketName = BucketName(UUID.randomUUID().toString)
         for {
-          _          <- ZStream.succeed(bucketName) >>> createBucket
-          wasCreated <- ZStream(bucketName) >>> existsBucket
+          _          <- ZStream.succeed(bucketName) >>> createBucket()
+          wasCreated <- ZStream(bucketName) >>> existsBucket()
           _          <- ZStream.fromChunk[Byte](Chunk(1, 2, 3)) >>> putObject(bucketName, ObjectKey(UUID.randomUUID().toString))
-          wasDeleted <- (ZStream.succeed(bucketName) >>> deleteEmptyBucket).as(true).catchSome { case _: S3Exception =>
-                          ZIO.succeed(false)
-                        }
+          wasDeleted <-
+            (ZStream.succeed(bucketName) >>> deleteEmptyBucket()).as(true).catchSome { case _: S3Exception =>
+              ZIO.succeed(false)
+            }
         } yield assertTrue(wasCreated) && assert(wasDeleted)(equalTo(false))
       },
       test("fails if bucket not exists") {
         val bucketName = BucketName(UUID.randomUUID().toString)
         for {
-          wasCreated <- ZStream(bucketName) >>> existsBucket
+          wasCreated <- ZStream(bucketName) >>> existsBucket()
           deleteFails <-
-            (ZStream.succeed(bucketName) >>> deleteEmptyBucket).as(false).catchSome { case _: S3Exception =>
+            (ZStream.succeed(bucketName) >>> deleteEmptyBucket()).as(false).catchSome { case _: S3Exception =>
               ZIO.succeed(true)
             }
         } yield assert(wasCreated)(equalTo(false)) && assertTrue(deleteFails)
@@ -105,9 +121,9 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
       test("succeeds if bucket is empty") {
         val bucketName = BucketName(UUID.randomUUID().toString)
         for {
-          _          <- ZStream.succeed(bucketName) >>> createBucket
-          wasCreated <- ZStream(bucketName) >>> existsBucket
-          wasDeleted <- (ZStream.succeed(bucketName) >>> deleteEmptyBucket).as(true)
+          _          <- ZStream.succeed(bucketName) >>> createBucket()
+          wasCreated <- ZStream(bucketName) >>> existsBucket()
+          wasDeleted <- (ZStream.succeed(bucketName) >>> deleteEmptyBucket()).as(true)
         } yield assertTrue(wasCreated) && assertTrue(wasDeleted)
       }
     )
@@ -118,9 +134,9 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
         val bucketName = BucketName(UUID.randomUUID().toString)
         val key        = ObjectKey(UUID.randomUUID().toString)
         for {
-          _                          <- ZStream.succeed(bucketName) >>> createBucket
-          objectExistsBeforeDeletion <- ZStream(key) >>> existsObject(bucketName)
-          _                          <- ZStream(key) >>> deleteObjects(bucketName)
+          _                          <- ZStream.succeed(bucketName) >>> createBucket()
+          objectExistsBeforeDeletion <- ZStream(key) >>> existsObject(bucketName, usEast1Region)
+          _                          <- ZStream(key) >>> deleteObjects(bucketName, usEast1Region)
         } yield assert(objectExistsBeforeDeletion)(equalTo(false))
       },
       test("succeeds") {
@@ -129,19 +145,19 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
         val key2       = ObjectKey(UUID.randomUUID().toString)
         val key3       = ObjectKey(UUID.randomUUID().toString)
         for {
-          _                           <- ZStream.succeed(bucketName) >>> createBucket
+          _                           <- ZStream.succeed(bucketName) >>> createBucket()
           _                           <- ZStream.fromChunk[Byte](Chunk(1, 2, 3)) >>> putObject(bucketName, key1)
           _                           <- ZStream.fromChunk[Byte](Chunk(1)) >>> putObject(bucketName, key2)
           _                           <- ZStream.fromChunk[Byte](Chunk(2)) >>> putObject(bucketName, key3)
-          object1ExistsBeforeDeletion <- ZStream(key1) >>> existsObject(bucketName)
-          object2ExistsBeforeDeletion <- ZStream(key2) >>> existsObject(bucketName)
-          object3ExistsBeforeDeletion <- ZStream(key3) >>> existsObject(bucketName)
+          object1ExistsBeforeDeletion <- ZStream(key1) >>> existsObject(bucketName, usEast1Region)
+          object2ExistsBeforeDeletion <- ZStream(key2) >>> existsObject(bucketName, usEast1Region)
+          object3ExistsBeforeDeletion <- ZStream(key3) >>> existsObject(bucketName, usEast1Region)
           objectsExistBeforeDeletion =
             object1ExistsBeforeDeletion && object2ExistsBeforeDeletion && object3ExistsBeforeDeletion
-          _                          <- ZStream(key1, key2, key3) >>> deleteObjects(bucketName)
-          object1ExistsAfterDeletion <- ZStream(key1) >>> existsObject(bucketName)
-          object2ExistsAfterDeletion <- ZStream(key2) >>> existsObject(bucketName)
-          object3ExistsAfterDeletion <- ZStream(key3) >>> existsObject(bucketName)
+          _                          <- ZStream(key1, key2, key3) >>> deleteObjects(bucketName, usEast1Region)
+          object1ExistsAfterDeletion <- ZStream(key1) >>> existsObject(bucketName, usEast1Region)
+          object2ExistsAfterDeletion <- ZStream(key2) >>> existsObject(bucketName, usEast1Region)
+          object3ExistsAfterDeletion <- ZStream(key3) >>> existsObject(bucketName, usEast1Region)
           objectsExistAfterDeletion =
             object1ExistsAfterDeletion || object2ExistsAfterDeletion || object3ExistsAfterDeletion
         } yield assertTrue(objectsExistBeforeDeletion) && assert(objectsExistAfterDeletion)(equalTo(false))
@@ -153,7 +169,7 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
       test("fails when bucket doesn't exist") {
         val bucketName = BucketName(UUID.randomUUID().toString)
         for {
-          exit <- listObjects(bucketName).runCollect.exit
+          exit <- listObjects(bucketName, usEast1Region).runCollect.exit
           failsWithExpectedError <-
             exit.as(false).catchSome { case S3Exception(_) => ZIO.succeed(true) }
         } yield assertTrue(failsWithExpectedError)
@@ -163,13 +179,13 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
         val obj1       = ObjectKey(UUID.randomUUID().toString)
         val obj2       = ObjectKey(UUID.randomUUID().toString)
         for {
-          _                   <- ZStream.succeed(bucketName) >>> createBucket
+          _                   <- ZStream.succeed(bucketName) >>> createBucket()
           testData            <- Random.nextBytes(5)
           _                   <- ZStream.fromChunk(testData) >>> putObject(bucketName, obj1)
           _                   <- ZStream.fromChunk(testData) >>> putObject(bucketName, obj2)
-          actual              <- listObjects(bucketName).runCollect
-          _                   <- ZStream.fromChunk(Chunk(obj1, obj2)) >>> deleteObjects(bucketName)
-          afterObjectDeletion <- listObjects(bucketName).runCollect
+          actual              <- listObjects(bucketName, usEast1Region).runCollect
+          _                   <- ZStream.fromChunk(Chunk(obj1, obj2)) >>> deleteObjects(bucketName, usEast1Region)
+          afterObjectDeletion <- listObjects(bucketName, usEast1Region).runCollect
         } yield assertTrue(actual.sortBy(_.toString) == Chunk(obj1, obj2).sortBy(_.toString)) && assertTrue(
           afterObjectDeletion.isEmpty
         )
@@ -178,18 +194,18 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
 
   private lazy val moveObjectSuite =
     suite("moveObject")(
-      test("replaces preexisting object") {
+      test("moves preexisting object") {
         val bucket1 = BucketName(UUID.randomUUID().toString)
         val bucket2 = BucketName(UUID.randomUUID().toString)
         val key     = ObjectKey(UUID.randomUUID().toString)
         for {
-          _             <- ZStream(bucket1, bucket2) >>> createBucket
+          _             <- ZStream(bucket1, bucket2) >>> createBucket()
           content1      <- Random.nextBytes(5)
           content2      <- Random.nextBytes(5)
           _             <- ZStream.fromChunk(content1) >>> putObject(bucket1, key)
           _             <- ZStream.fromChunk(content2) >>> putObject(bucket2, key)
-          _             <- ZStream(S3Connector.MoveObject(bucket1, key, bucket2, key)) >>> moveObject
-          copiedContent <- getObject(bucket2, key).runCollect
+          _             <- ZStream(S3Connector.MoveObject(bucket1, key, bucket2, key)) >>> moveObject()
+          copiedContent <- getObject(bucket2, key, usEast1Region).runCollect
         } yield assertTrue(copiedContent == content1)
       },
       test("succeeds") {
@@ -202,26 +218,41 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
         val key4    = ObjectKey(UUID.randomUUID().toString)
 
         for {
-          _                <- ZStream(bucket1, bucket2) >>> createBucket
+          _                <- ZStream(bucket1, bucket2) >>> createBucket()
           testDataK1       <- Random.nextBytes(5)
           _                <- ZStream.fromChunk(testDataK1) >>> putObject(bucket1, key1)
           testDataK2       <- Random.nextBytes(5)
           _                <- ZStream.fromChunk(testDataK2) >>> putObject(bucket1, key2)
           testDataK3       <- Random.nextBytes(5)
           _                <- ZStream.fromChunk(testDataK3) >>> putObject(bucket1, key3)
-          initialB1Objects <- listObjects(bucket1).runCollect
-          initialB2Objects <- listObjects(bucket2).runCollect
-          _                <- ZStream(S3Connector.CopyObject(bucket1, key1, bucket2)) >>> copyObject
-          _                <- ZStream(S3Connector.MoveObject(bucket1, key2, bucket2, key2)) >>> moveObject
-          _                <- ZStream(S3Connector.MoveObject(bucket1, key3, bucket2, key4)) >>> moveObject
-          b1Objects        <- listObjects(bucket1).runCollect
-          b2Objects        <- listObjects(bucket2).runCollect
+          initialB1Objects <- listObjects(bucket1, usEast1Region).runCollect
+          initialB2Objects <- listObjects(bucket2, usEast1Region).runCollect
+          _                <- ZStream(S3Connector.CopyObject(bucket1, key1, bucket2)) >>> copyObject()
+          _                <- ZStream(S3Connector.MoveObject(bucket1, key2, bucket2, key2)) >>> moveObject()
+          _                <- ZStream(S3Connector.MoveObject(bucket1, key3, bucket2, key4)) >>> moveObject()
+          b1Objects        <- listObjects(bucket1, usEast1Region).runCollect
+          b2Objects        <- listObjects(bucket2, usEast1Region).runCollect
 
         } yield assertTrue(initialB1Objects.sortBy(_.toString) == Chunk(key1, key2, key3).sortBy(_.toString)) &&
           assertTrue(initialB2Objects.isEmpty) &&
           assertTrue(b1Objects == Chunk(key1)) &&
           assertTrue(b2Objects.sortBy(_.toString) == Chunk(key1, key2, key4).sortBy(_.toString))
 
+      },
+      test("moves preexisting object cross region") {
+        val bucket1 = BucketName(UUID.randomUUID().toString)
+        val bucket2 = BucketName(UUID.randomUUID().toString)
+        val key     = ObjectKey(UUID.randomUUID().toString)
+        for {
+          _             <- ZStream(bucket1) >>> createBucket()
+          _             <- ZStream(bucket2) >>> createBucket(usWest2Region)
+          content1      <- Random.nextBytes(5)
+          content2      <- Random.nextBytes(5)
+          _             <- ZStream.fromChunk(content1) >>> putObject(bucket1, key)
+          _             <- ZStream.fromChunk(content2) >>> putObject(bucket2, key, usWest2Region)
+          _             <- ZStream(S3Connector.MoveObject(bucket1, key, bucket2, key)) >>> moveObject(usEast1Region, usWest2Region)
+          copiedContent <- getObject(bucket2, key, usWest2Region).runCollect
+        } yield assertTrue(copiedContent == content1)
       }
     )
 
@@ -231,10 +262,10 @@ trait S3ConnectorSpec extends ZIOSpecDefault {
         val bucketName = BucketName(UUID.randomUUID().toString)
         val objectKey  = ObjectKey(UUID.randomUUID().toString)
         for {
-          _        <- ZStream.succeed(bucketName) >>> createBucket
+          _        <- ZStream(bucketName) >>> createBucket()
           testData <- Random.nextBytes(5)
           _        <- ZStream.fromChunk(testData) >>> putObject(bucketName, objectKey)
-          actual   <- getObject(bucketName, objectKey).runCollect
+          actual   <- getObject(bucketName, objectKey, usEast1Region).runCollect
         } yield assertTrue(actual == testData)
       }
     )


### PR DESCRIPTION
Added an additional capability to pass S3 connector to the copyObject and moveObject. This connector pass to the method can refer to another s3 region. 