### PR TITLE
Removing redundant toString

### DIFF
--- a/connectors/s3-connector/src/main/scala/zio/connect/s3/LiveS3Connector.scala
+++ b/connectors/s3-connector/src/main/scala/zio/connect/s3/LiveS3Connector.scala
@@ -1,19 +1,8 @@
 package zio.connect.s3
 import zio.aws.core.AwsError
 import zio.aws.s3.S3
-import zio.aws.s3.model.primitives.{BucketName => AwsBucketName, ContentLength, CopySource, ObjectKey => AwsObjectKey}
-import zio.aws.s3.model.{
-  CopyObjectRequest,
-  CreateBucketRequest,
-  Delete,
-  DeleteBucketRequest,
-  DeleteObjectRequest,
-  DeleteObjectsRequest,
-  GetObjectRequest,
-  ListObjectsRequest,
-  ObjectIdentifier,
-  PutObjectRequest
-}
+import zio.aws.s3.model._
+import zio.aws.s3.model.primitives.{ContentLength, CopySource, BucketName => AwsBucketName, ObjectKey => AwsObjectKey}
 import zio.connect.s3.S3Connector.{BucketName, CopyObject, ObjectKey, S3Exception}
 import zio.stream.{ZSink, ZStream}
 import zio.{Chunk, Trace, ZIO, ZLayer}
@@ -28,8 +17,8 @@ final case class LiveS3Connector(s3: S3) extends S3Connector {
       .foreach[Any, AwsError, CopyObject] { m =>
         s3.copyObject(
           CopyObjectRequest(
-            destinationBucket = AwsBucketName(m.targetBucketName.toString),
-            destinationKey = AwsObjectKey(m.objectKey.toString),
+            destinationBucket = AwsBucketName(m.targetBucketName),
+            destinationKey = AwsObjectKey(m.objectKey),
             copySource =
               CopySource(URLEncoder.encode(s"${m.sourceBucketName}/${m.objectKey}", StandardCharsets.UTF_8.toString))
           )
@@ -40,14 +29,14 @@ final case class LiveS3Connector(s3: S3) extends S3Connector {
   override def createBucket(implicit trace: Trace): ZSink[Any, S3Exception, BucketName, BucketName, Unit] =
     ZSink
       .foreach[Any, AwsError, BucketName] { name =>
-        s3.createBucket(CreateBucketRequest(bucket = AwsBucketName(name.toString)))
+        s3.createBucket(CreateBucketRequest(bucket = AwsBucketName(name)))
       }
       .mapError(a => S3Exception(a.toThrowable))
 
   override def deleteEmptyBucket(implicit trace: Trace): ZSink[Any, S3Exception, BucketName, BucketName, Unit] =
     ZSink
       .foreach[Any, AwsError, BucketName] { name =>
-        s3.deleteBucket(DeleteBucketRequest(bucket = AwsBucketName(name.toString)))
+        s3.deleteBucket(DeleteBucketRequest(bucket = AwsBucketName(name)))
       }
       .mapError(a => S3Exception(a.toThrowable))
 
@@ -58,8 +47,8 @@ final case class LiveS3Connector(s3: S3) extends S3Connector {
       .foreachChunk[Any, AwsError, ObjectKey] { objectKeys =>
         s3.deleteObjects(
           DeleteObjectsRequest(
-            bucket = AwsBucketName(bucketName.toString),
-            delete = Delete(objects = objectKeys.map(a => ObjectIdentifier(AwsObjectKey(a.toString))))
+            bucket = AwsBucketName(bucketName),
+            delete = Delete(objects = objectKeys.map(a => ObjectIdentifier(AwsObjectKey(a))))
           )
         )
       }
@@ -70,7 +59,7 @@ final case class LiveS3Connector(s3: S3) extends S3Connector {
   ): ZStream[Any, S3Exception, Byte] =
     ZStream
       .unwrap(
-        s3.getObject(GetObjectRequest(bucket = AwsBucketName(bucketName.toString), key = AwsObjectKey(key.toString)))
+        s3.getObject(GetObjectRequest(bucket = AwsBucketName(bucketName), key = AwsObjectKey(key)))
           .map(a => a.output)
       )
       .mapError(a => S3Exception(a.toThrowable))
@@ -89,7 +78,7 @@ final case class LiveS3Connector(s3: S3) extends S3Connector {
   ): ZStream[Any, S3Exception, ObjectKey] =
     ZStream
       .fromIterableZIO(
-        s3.listObjects(ListObjectsRequest(bucket = AwsBucketName(bucketName.toString)))
+        s3.listObjects(ListObjectsRequest(bucket = AwsBucketName(bucketName)))
           .map(_.contents.map(_.flatMap(_.key.toChunk.map(ObjectKey(_)))).getOrElse(Chunk.empty[ObjectKey]))
       )
       .mapError(a => S3Exception(a.toThrowable))
@@ -101,15 +90,14 @@ final case class LiveS3Connector(s3: S3) extends S3Connector {
       .foreach[Any, AwsError, S3Connector.MoveObject] { m =>
         s3.copyObject(
           CopyObjectRequest(
-            destinationBucket = AwsBucketName(m.targetBucketName.toString),
-            destinationKey = AwsObjectKey(m.targetObjectKey.toString),
-            copySource =
-              CopySource(URLEncoder.encode(s"${m.bucketName}/${m.objectKey}", StandardCharsets.UTF_8.toString))
+            destinationBucket = AwsBucketName(m.targetBucketName),
+            destinationKey = AwsObjectKey(m.targetObjectKey),
+            copySource = CopySource(URLEncoder.encode(s"${m.bucketName}/${m.objectKey}", StandardCharsets.UTF_8))
           )
         ) *> s3.deleteObject(
           DeleteObjectRequest(
-            bucket = AwsBucketName(m.bucketName.toString),
-            key = AwsObjectKey(m.objectKey.toString)
+            bucket = AwsBucketName(m.bucketName),
+            key = AwsObjectKey(m.objectKey)
           )
         )
       }
@@ -122,8 +110,8 @@ final case class LiveS3Connector(s3: S3) extends S3Connector {
       .foreachChunk[Any, AwsError, Byte] { content =>
         s3.putObject(
           request = PutObjectRequest(
-            bucket = AwsBucketName(bucketName.toString),
-            key = AwsObjectKey(key.toString),
+            bucket = AwsBucketName(bucketName),
+            key = AwsObjectKey(key),
             contentLength = Some(ContentLength(content.length.toLong))
           ),
           body = ZStream.fromChunk(content).rechunk(1024)

--- a/connectors/s3-connector/src/main/scala/zio/connect/s3/S3Connector.scala
+++ b/connectors/s3-connector/src/main/scala/zio/connect/s3/S3Connector.scala
@@ -1,7 +1,7 @@
 package zio.connect.s3
 
-import zio.connect.s3.S3Connector.{BucketName, CopyObject, MoveObject, ObjectKey, S3Exception}
-import zio.prelude.Newtype
+import zio.connect.s3.S3Connector._
+import zio.prelude.Subtype
 import zio.stream.{ZSink, ZStream}
 import zio.{Trace, ZIO}
 
@@ -61,10 +61,10 @@ trait S3Connector {
 
 object S3Connector {
 
-  object BucketName extends Newtype[String]
+  object BucketName extends Subtype[String]
   type BucketName = BucketName.Type
 
-  object ObjectKey extends Newtype[String]
+  object ObjectKey extends Subtype[String]
   type ObjectKey = ObjectKey.Type
 
   case class S3Exception(reason: Throwable)

--- a/connectors/s3-connector/src/main/scala/zio/connect/s3/TestS3Connector.scala
+++ b/connectors/s3-connector/src/main/scala/zio/connect/s3/TestS3Connector.scala
@@ -1,11 +1,11 @@
 package zio.connect.s3
 
-import zio.connect.s3.S3Connector.{BucketName, CopyObject, MoveObject, ObjectKey, S3Exception}
+import zio.connect.s3.S3Connector._
 import zio.connect.s3.TestS3Connector.S3Node.{S3Bucket, S3Obj}
 import zio.connect.s3.TestS3Connector.TestS3
 import zio.stm.{STM, TRef, ZSTM}
 import zio.stream.{ZSink, ZStream}
-import zio.{Chunk, Trace, ZIO, ZLayer}
+import zio.{Chunk, Trace, ULayer, ZIO, ZLayer}
 
 private[s3] final case class TestS3Connector(s3: TestS3) extends S3Connector {
   override def copyObject(implicit
@@ -57,7 +57,7 @@ private[s3] final case class TestS3Connector(s3: TestS3) extends S3Connector {
 
 object TestS3Connector {
 
-  val layer: ZLayer[Any, Nothing, TestS3Connector] =
+  val layer: ULayer[TestS3Connector] =
     ZLayer.fromZIO(STM.atomically {
       for {
         a <- TRef.make(Map.empty[BucketName, S3Bucket])

--- a/connectors/s3-connector/src/main/scala/zio/connect/s3/package.scala
+++ b/connectors/s3-connector/src/main/scala/zio/connect/s3/package.scala
@@ -1,8 +1,9 @@
 package zio.connect
 
-import zio.Trace
+import zio.aws.s3.S3
 import zio.connect.s3.S3Connector.{BucketName, CopyObject, ObjectKey, S3Exception}
 import zio.stream.{ZSink, ZStream}
+import zio.{Trace, ULayer, URLayer}
 
 package object s3 {
 
@@ -41,8 +42,8 @@ package object s3 {
   ): ZSink[S3Connector, S3Exception, S3Connector.MoveObject, S3Connector.MoveObject, Unit] =
     ZSink.serviceWithSink(_.moveObject)
 
-  val s3ConnectorLiveLayer = LiveS3Connector.layer
-  val s3ConnectorTestLayer = TestS3Connector.layer
+  val s3ConnectorLiveLayer: URLayer[S3, LiveS3Connector] = LiveS3Connector.layer
+  val s3ConnectorTestLayer: ULayer[TestS3Connector]      = TestS3Connector.layer
 
   def putObject(bucketName: => BucketName, key: ObjectKey)(implicit
     trace: Trace

--- a/connectors/s3-connector/src/test/scala/zio/connect/s3/LiveS3ConnectorSpec.scala
+++ b/connectors/s3-connector/src/test/scala/zio/connect/s3/LiveS3ConnectorSpec.scala
@@ -5,12 +5,14 @@ import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import zio.aws.core.config.AwsConfig
+import zio.aws.core.httpclient.HttpClient
 import zio.aws.netty.NettyHttpClient
 import zio.aws.s3.S3
+import zio.test.Spec
 import zio.{Scope, ZIO, ZLayer}
 
 object LiveS3ConnectorSpec extends S3ConnectorSpec {
-  override def spec =
+  override def spec: Spec[Scope, Object] =
     suite("LiveS3ConnectorSpec")(s3ConnectorSpec)
       .provideSomeShared[Scope](
         localStackContainer,
@@ -19,8 +21,8 @@ object LiveS3ConnectorSpec extends S3ConnectorSpec {
         zio.connect.s3.s3ConnectorLiveLayer
       )
 
-  lazy val httpClient                                   = NettyHttpClient.default
-  lazy val awsConfig: ZLayer[Any, Throwable, AwsConfig] = httpClient >>> AwsConfig.default
+  lazy val httpClient: ZLayer[Any, Throwable, HttpClient] = NettyHttpClient.default
+  lazy val awsConfig: ZLayer[Any, Throwable, AwsConfig]   = httpClient >>> AwsConfig.default
 
   lazy val localStackContainer: ZLayer[Scope, Throwable, LocalStackContainer] =
     ZLayer.fromZIO(

--- a/connectors/s3-connector/src/test/scala/zio/connect/s3/TestS3ConnectorSpec.scala
+++ b/connectors/s3-connector/src/test/scala/zio/connect/s3/TestS3ConnectorSpec.scala
@@ -1,8 +1,10 @@
 package zio.connect.s3
+import zio.Scope
+import zio.test.{Spec, TestEnvironment}
 
 object TestS3ConnectorSpec extends S3ConnectorSpec {
 
-  override def spec =
+  override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("TestS3ConnectorSpec")(s3ConnectorSpec).provide(s3ConnectorTestLayer)
 
 }


### PR DESCRIPTION
Ticket  #103 Use subtype instead of newtype and refactor out redundant _.toString calls